### PR TITLE
Remove requiring changes to the OpenProject core

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,49 +175,6 @@ group :opf_plugins do
 end
 ```
 
-## Changes required in the OpenProject code
-
-Right now, as the plugin for Github works, it is required to add some lines of code in the core of the OpenProject code before the precompilation of the assets.
-
-Please modify the following files:
-
-#### 1) api-v3-work-package-paths.ts
-
-Path of the file that needs to be modified:
-
-```
-frontend/src/app/core/apiv3/endpoints/work_packages/api-v3-work-package-paths.ts
-```
-
-Add the following just after the line defining the Github resource (after line 52):
-
-```
-   // /api/v3/(?:projectPath)/work_packages/(:workPackageId)/gitlab_merge_requests
-   public readonly gitlab_merge_requests = this.subResource('gitlab_merge_requests');
-```
-
-This line of code is necessary so that when precompiling the plugin assets they do not generate an error.
-
-#### 2) work-package.rd
-
-Path of the file that needs to be modified:
-
-```
-app/models/work_package.rb
-```
-
-Add the following just after the line defining the Github table relation (after line 67):
-
-```
-has_and_belongs_to_many :gitlab_merge_requests
-```
-
-This line of code is necessary to display the content of the new Gitlab tab and not generate the error:
-
-```
-undefined method `gitlab_merge_requests' for #<WorkPackage:0x000056127ee75b30>
-```
-
 ### The Gitlab Bot user in OpenProject
 
 First you will need to create a user in OpenProject that will make the comments. The user will have to be added to each project with a role that allows them to comment on work packages and change status.

--- a/frontend/module/merge-request/merge-request.component.ts
+++ b/frontend/module/merge-request/merge-request.component.ts
@@ -29,9 +29,9 @@
 
 import { Component, Input } from '@angular/core';
 import { GitlabPipelineResource } from '../hal/resources/gitlab-pipelines-resource';
-import { IGitlabMergeRequestResource } from "../../../../../../../../modules/gitlab_integration/frontend/module/typings";
-import { PathHelperService } from "core-app/core/path-helper/path-helper.service";
-import { I18nService } from "core-app/core/i18n/i18n.service";
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import {IGitlabMergeRequestResource} from 'core-app/features/plugins/linked/openproject-gitlab_integration/typings';
 
 @Component({
   selector: 'gitlab-merge-request',

--- a/frontend/module/tab-mrs/tab-mrs.component.ts
+++ b/frontend/module/tab-mrs/tab-mrs.component.ts
@@ -29,11 +29,11 @@
 
 import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
-import { APIV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { HalResourceService } from "core-app/features/hal/services/hal-resource.service";
 import { CollectionResource } from "core-app/features/hal/resources/collection-resource";
-import { IGitlabMergeRequestResource } from "../../../../../../../../modules/gitlab_integration/frontend/module/typings";
 import { I18nService } from "core-app/core/i18n/i18n.service";
+import {IGitlabMergeRequestResource} from "core-app/features/plugins/linked/openproject-gitlab_integration/typings";
+import {ApiV3Service} from "core-app/core/apiv3/api-v3.service";
 
 @Component({
   selector: 'tab-mrs',
@@ -47,13 +47,14 @@ export class TabMrsComponent implements OnInit {
 
   constructor(
     readonly I18n:I18nService,
-    readonly apiV3Service:APIV3Service,
+    readonly apiV3Service:ApiV3Service,
     readonly halResourceService:HalResourceService,
     readonly changeDetector:ChangeDetectorRef,
   ) {}
 
   ngOnInit(): void {
-    const mergeRequestsPath = this.apiV3Service.work_packages.id({id: this.workPackage.id })?.gitlab_merge_requests.path;
+    const basePath = this.apiV3Service.work_packages.id(this.workPackage.id as string).path;
+    const mergeRequestsPath = `${basePath}/gitlab_merge_requests`;
 
     this.halResourceService
       .get<CollectionResource<IGitlabMergeRequestResource>>(mergeRequestsPath)

--- a/frontend/module/tab-mrs/tab-mrs.component.ts
+++ b/frontend/module/tab-mrs/tab-mrs.component.ts
@@ -33,7 +33,7 @@ import { HalResourceService } from "core-app/features/hal/services/hal-resource.
 import { CollectionResource } from "core-app/features/hal/resources/collection-resource";
 import { I18nService } from "core-app/core/i18n/i18n.service";
 import {IGitlabMergeRequestResource} from "core-app/features/plugins/linked/openproject-gitlab_integration/typings";
-import {ApiV3Service} from "core-app/core/apiv3/api-v3.service";
+import {APIV3Service} from "core-app/core/apiv3/api-v3.service";
 
 @Component({
   selector: 'tab-mrs',
@@ -47,7 +47,7 @@ export class TabMrsComponent implements OnInit {
 
   constructor(
     readonly I18n:I18nService,
-    readonly apiV3Service:ApiV3Service,
+    readonly apiV3Service:APIV3Service,
     readonly halResourceService:HalResourceService,
     readonly changeDetector:ChangeDetectorRef,
   ) {}

--- a/lib/open_project/gitlab_integration/engine.rb
+++ b/lib/open_project/gitlab_integration/engine.rb
@@ -44,6 +44,7 @@ module OpenProject::GitlabIntegration
              :author_url => 'https://github.com/btey/openproject',
              bundled: true
 
+    patches %w[WorkPackage]
 
     initializer 'gitlab.register_hook' do
       ::OpenProject::Webhooks.register_hook 'gitlab' do |hook, environment, params, user|

--- a/lib/open_project/gitlab_integration/patches/work_package_patch.rb
+++ b/lib/open_project/gitlab_integration/patches/work_package_patch.rb
@@ -1,0 +1,13 @@
+module OpenProject::GitlabIntegration
+  module Patches
+    module WorkPackagePatch
+      extend ActiveSupport::Concern
+
+      included do
+        has_and_belongs_to_many :gitlab_merge_requests
+      end
+    end
+  end
+end
+
+::WorkPackage.include OpenProject::GitlabIntegration::Patches::WorkPackagePatch


### PR DESCRIPTION
I've taken a look at your plugin, great stuff! Thanks for all your efforts in building it. I've seen that you right now require changes to the OpenProject core for the plugin to work.

While right now we don't have a solution for extending paths to the frontend APIv3 service (I'll look into that!), you can avoid the second part with adding a patch/include for work packages.

For the first part, instead of requiring users to extend the path, you can simply build the path yourself until we can provide you with a more sane API to extend the APIv3Service.

I also removed some relative import paths that prevent the plugin from building correctly when the plugin is linked. I'd recommend that if you work with the plugin, you do frontend work with an IDE/VS Code from within the linked frontend, as there it will pick up the tsconfig paths mapping and make importing work as expected.

The reasoning behind this is written up here https://github.com/opf/openproject-proto_plugin#frontend-linking. It's a bit unfortunate but Angular CLI just doesn't provide us with any means (that I know) to have a linked plugin  build working without such a symlink construction.

Let me know what you think! You can reach out to me at o.guenther@openproject.com or @o.guenther:openproject.org on matrix