### PR TITLE
Open Project v12.2.0 build fix

### DIFF
--- a/lib/open_project/gitlab_integration/engine.rb
+++ b/lib/open_project/gitlab_integration/engine.rb
@@ -66,11 +66,13 @@ module OpenProject::GitlabIntegration
     end
 
     initializer 'gitlab.permissions' do
-      OpenProject::AccessControl.map do |ac_map|
-        ac_map.project_module(:gitlab, dependencies: :work_package_tracking) do |pm_map|
-          pm_map.permission(:show_gitlab_content, {})
+	  Rails.application.reloader.to_prepare do
+        OpenProject::AccessControl.map do |ac_map|
+          ac_map.project_module(:gitlab, dependencies: :work_package_tracking) do |pm_map|
+            pm_map.permission(:show_gitlab_content, {})
+          end
         end
-      end
+	  end
     end
 
     extend_api_response(:v3, :work_packages, :work_package,

--- a/lib/open_project/gitlab_integration/engine.rb
+++ b/lib/open_project/gitlab_integration/engine.rb
@@ -72,7 +72,7 @@ module OpenProject::GitlabIntegration
             pm_map.permission(:show_gitlab_content, {})
           end
         end
-	  end
+      end
     end
 
     extend_api_response(:v3, :work_packages, :work_package,


### PR DESCRIPTION
From open project v12.2.0 "OpenProject::AccessControl.map" need to be inside Rails.application.reloader.to_prepare

Without the change I get "NameError: uninitialized constant OpenProject::AccessControl" in docker build

The plugin seems to work otherwise. Tested with v12.2.1

