### PR TITLE
OpenProject 12.2 compatibility

### DIFF
--- a/lib/open_project/gitlab_integration/engine.rb
+++ b/lib/open_project/gitlab_integration/engine.rb
@@ -42,7 +42,11 @@ module OpenProject::GitlabIntegration
 
     register 'openproject-gitlab_integration',
              :author_url => 'https://github.com/btey/openproject',
-             bundled: true
+             bundled: true do
+      project_module(:gitlab, dependencies: :work_package_tracking) do
+        permission(:show_gitlab_content, {})
+      end
+    end
 
     patches %w[WorkPackage]
 
@@ -63,14 +67,6 @@ module OpenProject::GitlabIntegration
                                              &NotificationHandlers.method(:push_hook))
       ::OpenProject::Notifications.subscribe('gitlab.pipeline_hook',
                                              &NotificationHandlers.method(:pipeline_hook))
-    end
-
-    initializer 'gitlab.permissions' do
-      OpenProject::AccessControl.map do |ac_map|
-        ac_map.project_module(:gitlab, dependencies: :work_package_tracking) do |pm_map|
-          pm_map.permission(:show_gitlab_content, {})
-        end
-      end
     end
 
     extend_api_response(:v3, :work_packages, :work_package,


### PR DESCRIPTION
This is a follow-up of https://github.com/btey/openproject-gitlab-integration/pull/19#issuecomment-1222850942


OpenProject 12.2. bumps Rails to 7.0, which removes the possibility to do autoloading in initializers. That's why some of the initializer blocks around permissions and shifts around some constants to other folders.

To avoid this, we can simply use the built-in mechanism to register a module and the necessary permissions