### PR TITLE
add fixed-keyword trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ OpenProject will **add comments** to work package for the following events:
 
 OpenProject will **update WP status** in this events:
 
-* Merge Request (opened) - Status: In progress (currently ID=7)
-* Merge Request (merged) - Status: Developed (currently ID=8)
+* Merge Request (opened)         - Status: In progress (currently ID=7)
+* Merge Request (merged)         - Status: Developed (currently ID=8)
+* Push Request ("fixed"-keyword) - Status: Developed (currently ID=8)
 
-> **Note about the status.** If you want to change the ID of the status you can do this in this section of the [code](https://github.com/btey/openproject-gitlab-integration/blob/master/lib/open_project/gitlab_integration/notification_handler/merge_request_hook.rb#L40-L41). By default is *disabled*, you can enable it by setting to `true` this [lines](https://github.com/btey/openproject-gitlab-integration/blob/master/lib/open_project/gitlab_integration/notification_handler/merge_request_hook.rb#L38-L39).
+> **Note about the status.** If you want to change the ID of the status with merge, you can do this in this section of the [code](https://github.com/btey/openproject-gitlab-integration/blob/master/lib/open_project/gitlab_integration/notification_handler/merge_request_hook.rb#L40-L41).By default is *disabled*, you can enable it by setting to `true` this [lines](https://github.com/btey/openproject-gitlab-integration/blob/master/lib/open_project/gitlab_integration/notification_handler/merge_request_hook.rb#L38-L39).
+If you want to change the ID of the status with "fixed"-keyword, you can do this in this section of the [code](https://github.com/btey/openproject-gitlab-integration/blob/master/lib/open_project/gitlab_integration/notification_handler/push_hook.rb#L40). By default is *disabled*, you can enable it by setting to `true` this [line](https://github.com/btey/openproject-gitlab-integration/blob/master/lib/open_project/gitlab_integration/notification_handler/push_hook.rb#L38).
 
 ## Example workflow
 

--- a/lib/open_project/gitlab_integration/notification_handler/push_hook.rb
+++ b/lib/open_project/gitlab_integration/notification_handler/push_hook.rb
@@ -35,6 +35,10 @@ module OpenProject::GitlabIntegration
       include OpenProject::GitlabIntegration::NotificationHandler::Helper
       
       def process(payload_params)
+        update_status_on_fixed = false # true if you only reference one commit by work_package, else false.
+
+        wp_status_id_on_fixed = 8 # the id of the status.
+
         @payload = wrap_payload(payload_params)
         return nil unless payload.object_kind == 'push'
         payload.commits.each do |commit|
@@ -43,6 +47,9 @@ module OpenProject::GitlabIntegration
           work_packages = find_mentioned_work_packages(text, user)
           notes = generate_notes(commit, payload)
           comment_on_referenced_work_packages(work_packages, user, notes)
+          if (text.include? "fixed") && (update_status_on_fixed)
+            status_on_referenced_work_packages(work_packages, user, wp_status_id_on_fixed)
+          end
         end
       end
 


### PR DESCRIPTION
I added ability to set status of WP with Commit and keyword "fixed"
This is disabled by default

ReadMe is adapted as well

Take care of #24 