### PR TITLE
Snippet for commit message contained wrong task code

### DIFF
--- a/frontend/module/git-actions/git-actions.service.ts
+++ b/frontend/module/git-actions/git-actions.service.ts
@@ -73,7 +73,7 @@ export class GitActionsService {
 
   public commitMessage(workPackage:WorkPackageResource):string {
     const { title, id, description, url } = this.formattingInput(workPackage);
-    return `[#${id}] ${title}
+    return `OP#${id} ${title}
 
 ${description}
 


### PR DESCRIPTION
Before — `[#8567] Commit message`
After — `OP#8567 Commit message`

Tested by me.