### PR TITLE
fix 500 errors with empty MR and Issue description body, fix empty av…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Introducing OpenProject GitLab Integration v2.1 GA
+## Introducing OpenProject GitLab Integration v2.1.1 GA
 
 Based on the OpenProject Github Integration, this plugin offers the same functionalities plus other new features. This is the first version that includes the visualization of the status of the *Pipelines* (by now, it is considered in Beta status). You can test it by activating the Pipelines event in the GitLab webhook. Just keep in mind that not all pipelines will be reflected in OpenProject, only Merge Request type pipelines (for more information see the GitLab issue https://gitlab.com/gitlab-org/gitlab/-/issues/345028). Any feedback about the pipelines feature would be very appreciated, whether it works or if issues arise (you can use this ticket https://github.com/btey/openproject-gitlab-integration/issues/43).
 
@@ -15,7 +15,7 @@ If there are labels related to the Issue or MR, a button with the label icon wil
 
 OpenProject module for integration with GitLab:
 * Latest Gitlab release tested: **16.5.1**
-* Latest OpenProject release tested: **13.0.7**
+* Latest OpenProject release tested: **13.0.8**
 
 The reference system is based on the same system as for GitHub integration. You can use a link to the work package or just use “OP#87” or "PP#87" in the title/description of the Issue/MR in GitLab.
 
@@ -47,89 +47,89 @@ OpenProject will **update WP status** in this events:
 A typical workflow on GitLab side would be:
 
 1. **Create Issue.**
-   
+
    <img src="doc/op-issue-opened.png" width="500">
-   
+
    > **Issue Opened:** Issue 6 New contact form - OP#18 for Scrum project has been opened by Administrator.
 
 2. **Comment on issue.**
-   
+
    If the reference is included in the title, the comments will not need a reference. By default, all comments will use the title as a reference.
-   
+
    <img src="doc/op-commented-in-issue.png" width="500">
-   
+
    > **Commented in Issue:** Administrator commented this WP in Issue 6 New contact form - OP#18 on Scrum project:
-   > 
+   >
    > New comment on the issue with attachment.
 
 3. **Create Merge Request.**
-   
+
    <img src="doc/op-mr-opened.png" width="500">
-   
+
    > **MR Opened:** Merge request 25 Draft: Resolve "New contact form - OP#18" for Scrum project has been opened by Administrator.
-   > 
+   >
    > **Status** changed from _Specified_
    > **to** _In progress_
 
 4. **Comment in Merge Request.**
-   
+
    <img src="doc/op-commented-in-mr.png" width="500">
-   
+
    > **Commented in MR:** Administrator commented this WP in Merge request 25 Draft: Resolve "New contact form - OP#18" on Scrum project:
-   > 
+   >
    > New comment on MR.
 
 5. **Reference in other Issues or Merge Request (comments).**
-   
+
    If the reference is NOT included in the title of the Issue/MR, the comments will need a reference. In OpenProject the comment will be saved as "referenced" in Issue/MR.
-   
+
    <img src="doc/op-referenced-in-issue.png" width="500">
-   
+
    > **Referenced in Issue:** Administrator referenced this WP in Issue 2 New backend pipeline on Scrum project:
-   > 
+   >
    > OP#18 New comment about...
-   > 
-   > **Note:** If you use the reference `PP#` in the title of the Issue/MR, you can use `OP#` in the comment to generate the same type of comment in OpenProject. 
+   >
+   > **Note:** If you use the reference `PP#` in the title of the Issue/MR, you can use `OP#` in the comment to generate the same type of comment in OpenProject.
 
 6. **New commit in Merge Request.**
-   
+
    <img src="doc/op-pushed-in-mr.png" width="500">
-   
+
    > **Pushed in MR:** Administrator pushed fca3d6fb to Scrum project at 2021-03-08T08:01:57+00:00:
-   > 
+   >
    > Update readme.md OP#18
 
 7. **Comment in a new commit of the Merge Request.**
-   
+
    <img src="doc/op-referenced-in-commit.png" width="500">
-   
+
    > **Referenced in Commit:** Administrator referenced this WP in a Commit Note 0bf0e3e9 on Scrum project:
-   > 
+   >
    > This change is for OP#18.
 
 8. **Merge Request merged (generates up to 3 events).**
-   
+
    <img src="doc/op-mr-merged-event-2.png" width="500">
-   
+
    > **Pushed in MR:** Administrator pushed 1da09cb4 to Scrum project at 2021-03-05T14:57:37+00:00:
-   > 
+   >
    > Merge branch '5-new-contact-form-op-18' into 'master'
-   > 
+   >
    > Resolve "New contact form - OP#18"
-   > 
+   >
    > Closes #6
-   > 
+   >
    > See merge request root/scrum!9
-   
+
    <img src="doc/op-mr-merged-event-3.png" width="500">
-   
+
    > **MR Merged:** Merge request 24 Resolve "New contact form - OP#18" for Scrum project has been merged by Administrator.
-   > 
+   >
    > **Status** changed from _In progress_
    > **to** _Developed_
-   
+
    <img src="doc/op-mr-merged-event-4.png" width="500">
-   
+
    > **Issue Closed:** Issue 6 New contact form - OP#18 for Scrum project has been closed by Administrator.
 
 ## Configuration
@@ -159,7 +159,7 @@ Add the following in **Gemfile.lock**:
 PATH
   remote: modules/gitlab_integration
   specs:
-    openproject-gitlab_integration (2.1)
+    openproject-gitlab_integration (2.1.1)
       openproject-webhooks
 ```
 
@@ -184,10 +184,10 @@ group :opf_plugins do
 end
 ```
 
-**Note:** It's possible that you need to use these commands before and after the "bundle install" if you get an error in this step warning about a change in the Gemfile:
+**Note:** It's possible that you need to use these commands before and after the `bundle install` if you get an error in this step warning about a change in the Gemfile:
 
 ```shell
-bundle config unset deployment 
+bundle config unset deployment
 bundle install --deployment --without mysql2 sqlite development test therubyracer docker
 bundle config set deployment
 ```
@@ -211,16 +211,16 @@ In GitLab you have to [set up a webhook](https://docs.gitlab.com/ee/user/project
 You need to configure just two things in the webhook:
 
 1. The URL must point to your OpenProject server’s GitLab webhook endpoint (/webhooks/gitlab). Append it to the URL as a simple GET parameter named key. In the end the URL should look something like this:
-   
+
    ```
    http://openproject-url.com/webhooks/gitlab?key=ae278268
    ```
 
-2. Enable the required triggers:   
-   1. Push events   
-   2. Comments   
+2. Enable the required triggers:
+   1. Push events
+   2. Comments
    3. Issues events
-   4. Merge request events  
+   4. Merge request events
    5. Pipeline events
 
 Now the integration is set up on both sides and you can use it.

--- a/config/locales/crowdin/ru.yml
+++ b/config/locales/crowdin/ru.yml
@@ -75,7 +75,7 @@ ru:
     issue_opened_referenced_comment: >
       **Обсуждение открыто:** Обсуждение %{issue_number} [%{issue_title}](%{issue_url}) в [%{repository}](%{repository_url})
       был открыт [%{gitlab_user}](%{gitlab_user_url}).
-    issue_закрыт_referenced_comment: >
+    issue_closed_referenced_comment: >
       **Обсуждение закрыто:** Обсуждение %{issue_number} [%{issue_title}](%{issue_url}) в [%{repository}](%{repository_url})
       был закрыт [%{gitlab_user}](%{gitlab_user_url}).
     issue_reopened_referenced_comment: >

--- a/lib/open_project/gitlab_integration/services/upsert_gitlab_user.rb
+++ b/lib/open_project/gitlab_integration/services/upsert_gitlab_user.rb
@@ -1,4 +1,4 @@
-#-- encoding: UTF-8
+# frozen_string_literal: true
 
 #-- copyright
 # OpenProject is an open source project management software.
@@ -27,34 +27,44 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-module OpenProject::GitlabIntegration::Services
-  ##
-  # Takes user data coming from Gitlab webhook data and stores
-  # them as a `GitlabUser`.
-  # If the `GitlabUser` already exists, it is updated.
-  #
-  # Returns the upserted `GitlabUser`.
-  class UpsertGitlabUser
-    def call(payload)
-      GitlabUser.find_or_initialize_by(gitlab_id: payload.id)
-                .tap do |gitlab_user|
-                  gitlab_user.update!(extract_params(payload))
-                end
-    end
+module OpenProject
+  module GitlabIntegration
+    module Services
+      ##
+      # Takes user data coming from Gitlab webhook data and stores
+      # them as a `GitlabUser`.
+      # If the `GitlabUser` already exists, it is updated.
+      #
+      # Returns the upserted `GitlabUser`.
+      class UpsertGitlabUser
+        def call(payload)
+          GitlabUser.find_or_initialize_by(gitlab_id: payload.id)
+                    .tap do |gitlab_user|
+                      gitlab_user.update!(extract_params(payload))
+                    end
+        end
 
-    private
+        private
 
-    ##
-    # Receives the input from the gitlab webhook and translates them
-    # to our internal representation.
-    def extract_params(payload)
-      {
-        gitlab_id: payload.id,
-        gitlab_name: payload.name, 
-        gitlab_username: payload.username, 
-        gitlab_email: payload.email, 
-        gitlab_avatar_url: payload.avatar_url
-      }
+        ##
+        # Receives the input from the gitlab webhook and translates them
+        # to our internal representation.
+        def extract_params(payload)
+          {
+            gitlab_id: payload.id,
+            gitlab_name: payload.name,
+            gitlab_username: payload.username,
+            gitlab_email: payload.email,
+            gitlab_avatar_url: avatar_url(payload)
+          }
+        end
+
+        def avatar_url(payload)
+          # rubocop:disable Layout/LineLength
+          payload.avatar_url.presence || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M12 2.5a5.5 5.5 0 0 1 3.096 10.047 9.005 9.005 0 0 1 5.9 8.181.75.75 0 1 1-1.499.044 7.5 7.5 0 0 0-14.993 0 .75.75 0 0 1-1.5-.045 9.005 9.005 0 0 1 5.9-8.18A5.5 5.5 0 0 1 12 2.5ZM8 8a4 4 0 1 0 8 0 4 4 0 0 0-8 0Z'%3E%3C/path%3E%3C/svg%3E"
+          # rubocop:enable Layout/LineLength
+        end
+      end
     end
   end
 end

--- a/lib/open_project/gitlab_integration/services/upsert_gitlab_user.rb
+++ b/lib/open_project/gitlab_integration/services/upsert_gitlab_user.rb
@@ -60,9 +60,7 @@ module OpenProject
         end
 
         def avatar_url(payload)
-          # rubocop:disable Layout/LineLength
-          payload.avatar_url.presence || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M12 2.5a5.5 5.5 0 0 1 3.096 10.047 9.005 9.005 0 0 1 5.9 8.181.75.75 0 1 1-1.499.044 7.5 7.5 0 0 0-14.993 0 .75.75 0 0 1-1.5-.045 9.005 9.005 0 0 1 5.9-8.18A5.5 5.5 0 0 1 12 2.5ZM8 8a4 4 0 1 0 8 0 4 4 0 0 0-8 0Z'%3E%3C/path%3E%3C/svg%3E"
-          # rubocop:enable Layout/LineLength
+          payload.avatar_url.presence || 'https://www.gravatar.com/avatar/?d=mp'
         end
       end
     end

--- a/lib/open_project/gitlab_integration/services/upsert_issue.rb
+++ b/lib/open_project/gitlab_integration/services/upsert_issue.rb
@@ -1,4 +1,4 @@
-#-- encoding: UTF-8
+# frozen_string_literal: true
 
 #-- copyright
 # OpenProject is an open source project management software.
@@ -27,58 +27,66 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-module OpenProject::GitlabIntegration::Services
-  ##
-  # Takes merge request data coming from Gitlab webhook data and stores
-  # them as a `GitlabMergeRequest`.
-  # If the `GitlabMergeRequest` already exists, it is updated.
-  #
-  # Returns the upserted `GitlabMergeRequest`.
-  class UpsertIssue
-    def call(payload, work_packages: [])
-      find_or_initialize(payload).tap do |issue|
-        issue.update!(work_packages: issue.work_packages | work_packages, **extract_params(payload))
+module OpenProject
+  module GitlabIntegration
+    module Services
+      ##
+      # Takes merge request data coming from Gitlab webhook data and stores
+      # them as a `GitlabMergeRequest`.
+      # If the `GitlabMergeRequest` already exists, it is updated.
+      #
+      # Returns the upserted `GitlabMergeRequest`.
+      class UpsertIssue
+        def call(payload, work_packages: [])
+          find_or_initialize(payload).tap do |issue|
+            issue.update!(work_packages: issue.work_packages | work_packages, **extract_params(payload))
+          end
+        end
+
+        private
+
+        def find_or_initialize(payload)
+          GitlabIssue.find_by_gitlab_identifiers(id: payload.object_attributes.iid,
+                                                 url: payload.object_attributes.url,
+                                                 initialize: true)
+        end
+
+        # Receives the input from the gitlab webhook and translates them
+        # to our internal representation.
+        # rubocop:disable Metrics/AbcSize
+        def extract_params(payload)
+          {
+            gitlab_id: payload.object_attributes.iid,
+            gitlab_user: gitlab_user_id(payload.user),
+            number: payload.object_attributes.iid,
+            gitlab_html_url: payload.object_attributes.url,
+            gitlab_updated_at: payload.object_attributes.updated_at,
+            state: payload.object_attributes.state,
+            title: payload.object_attributes.title,
+            body: description(payload),
+            repository: payload.repository.name,
+            labels: payload.labels.map { |values| extract_label_values(values) }
+          }
+        end
+        # rubocop:enable Metrics/AbcSize
+
+        def extract_label_values(payload)
+          {
+            title: payload['title'],
+            color: payload['color']
+          }
+        end
+
+        def gitlab_user_id(payload)
+          return if payload.blank?
+
+          ::OpenProject::GitlabIntegration::Services::UpsertGitlabUser.new.call(payload)
+        end
+
+        def description(payload)
+          payload.object_attributes.description.presence || 'No description provided'
+        end
       end
-    end
-
-    private
-
-    def find_or_initialize(payload)
-      GitlabIssue.find_by_gitlab_identifiers(id: payload.object_attributes.iid,
-                                                   url: payload.object_attributes.url,
-                                                   initialize: true)
-    end
-
-    # Receives the input from the gitlab webhook and translates them
-    # to our internal representation.
-    # rubocop:disable Metrics/AbcSize
-    def extract_params(payload)
-      {
-        gitlab_id: payload.object_attributes.iid,
-        gitlab_user: gitlab_user_id(payload.user),
-        number: payload.object_attributes.iid,
-        gitlab_html_url: payload.object_attributes.url,
-        gitlab_updated_at: payload.object_attributes.updated_at,
-        state: payload.object_attributes.state,
-        title: payload.object_attributes.title,
-        body: payload.object_attributes.description,
-        repository: payload.repository.name,
-        labels: payload.labels.map { |values| extract_label_values(values) }
-      }
-    end
-    # rubocop:enable Metrics/AbcSize
-
-    def extract_label_values(payload)
-      {
-        title: payload['title'],
-        color: payload['color']
-      }
-    end
-
-    def gitlab_user_id(payload)
-      return if payload.blank?
-
-      ::OpenProject::GitlabIntegration::Services::UpsertGitlabUser.new.call(payload)
     end
   end
 end

--- a/lib/open_project/gitlab_integration/services/upsert_merge_request.rb
+++ b/lib/open_project/gitlab_integration/services/upsert_merge_request.rb
@@ -1,4 +1,4 @@
-#-- encoding: UTF-8
+# frozen_string_literal: true
 
 #-- copyright
 # OpenProject is an open source project management software.
@@ -27,62 +27,70 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-module OpenProject::GitlabIntegration::Services
-  ##
-  # Takes merge request data coming from Gitlab webhook data and stores
-  # them as a `GitlabMergeRequest`.
-  # If the `GitlabMergeRequest` already exists, it is updated.
-  #
-  # Returns the upserted `GitlabMergeRequest`.
-  class UpsertMergeRequest
-    def call(payload, work_packages: [])
-      find_or_initialize(payload).tap do |mr|
-        mr.update!(work_packages: mr.work_packages | work_packages, **extract_params(payload))
+module OpenProject
+  module GitlabIntegration
+    module Services
+      ##
+      # Takes merge request data coming from Gitlab webhook data and stores
+      # them as a `GitlabMergeRequest`.
+      # If the `GitlabMergeRequest` already exists, it is updated.
+      #
+      # Returns the upserted `GitlabMergeRequest`.
+      class UpsertMergeRequest
+        def call(payload, work_packages: [])
+          find_or_initialize(payload).tap do |mr|
+            mr.update!(work_packages: mr.work_packages | work_packages, **extract_params(payload))
+          end
+        end
+
+        private
+
+        def find_or_initialize(payload)
+          GitlabMergeRequest.find_by_gitlab_identifiers(id: payload.object_attributes.iid,
+                                                        url: payload.object_attributes.url,
+                                                        initialize: true)
+        end
+
+        # Receives the input from the gitlab webhook and translates them
+        # to our internal representation.
+        # rubocop:disable Metrics/AbcSize
+        def extract_params(payload)
+          {
+            gitlab_id: payload.object_attributes.iid,
+            gitlab_user: gitlab_user_id(payload.user),
+            number: payload.object_attributes.iid,
+            gitlab_html_url: payload.object_attributes.url,
+            gitlab_updated_at: payload.object_attributes.updated_at,
+            state: payload.object_attributes.state,
+            title: payload.object_attributes.title,
+            body: description(payload),
+            repository: payload.repository.name,
+            draft: payload.object_attributes.work_in_progress,
+            merged: payload.object_attributes.state == 'merged',
+            merged_by: gitlab_user_id(payload.user),
+            merged_at: payload.object_attributes.state == 'merged' ? payload.object_attributes.updated_at : nil,
+            labels: payload.labels.map { |values| extract_label_values(values) }
+          }
+        end
+        # rubocop:enable Metrics/AbcSize
+
+        def extract_label_values(payload)
+          {
+            title: payload['title'],
+            color: payload['color']
+          }
+        end
+
+        def gitlab_user_id(payload)
+          return if payload.blank?
+
+          ::OpenProject::GitlabIntegration::Services::UpsertGitlabUser.new.call(payload)
+        end
+
+        def description(payload)
+          payload.object_attributes.description.presence || 'No description provided'
+        end
       end
-    end
-
-    private
-
-    def find_or_initialize(payload)
-      GitlabMergeRequest.find_by_gitlab_identifiers(id: payload.object_attributes.iid,
-                                                   url: payload.object_attributes.url,
-                                                   initialize: true)
-    end
-
-    # Receives the input from the gitlab webhook and translates them
-    # to our internal representation.
-    # rubocop:disable Metrics/AbcSize
-    def extract_params(payload)
-      {
-        gitlab_id: payload.object_attributes.iid,
-        gitlab_user: gitlab_user_id(payload.user),
-        number: payload.object_attributes.iid,
-        gitlab_html_url: payload.object_attributes.url,
-        gitlab_updated_at: payload.object_attributes.updated_at,
-        state: payload.object_attributes.state,
-        title: payload.object_attributes.title,
-        body: payload.object_attributes.description,
-        repository: payload.repository.name,
-        draft: payload.object_attributes.work_in_progress,
-        merged: payload.object_attributes.state == 'merged' ? true : false,
-        merged_by: gitlab_user_id(payload.user),
-        merged_at: payload.object_attributes.state == 'merged' ? payload.object_attributes.updated_at : nil,
-        labels: payload.labels.map { |values| extract_label_values(values) }
-      }
-    end
-    # rubocop:enable Metrics/AbcSize
-
-    def extract_label_values(payload)
-      {
-        title: payload['title'],
-        color: payload['color']
-      }
-    end
-
-    def gitlab_user_id(payload)
-      return if payload.blank?
-
-      ::OpenProject::GitlabIntegration::Services::UpsertGitlabUser.new.call(payload)
     end
   end
 end

--- a/openproject-gitlab_integration.gemspec
+++ b/openproject-gitlab_integration.gemspec
@@ -1,4 +1,5 @@
-# encoding: UTF-8
+# frozen_string_literal: true
+
 #
 #-- copyright
 # OpenProject is an open source project management software.
@@ -30,16 +31,16 @@
 #++
 
 Gem::Specification.new do |s|
-  s.name        = "openproject-gitlab_integration"
-  s.version     = '2.1'
-  s.authors     = "Ben Tey"
-  s.email       = "ben.tey@outlook.com"
-  s.homepage    = "https://github.com/btey/openproject-gitlab-integration"
+  s.name        = 'openproject-gitlab_integration'
+  s.version     = '2.1.1'
+  s.authors     = 'Ben Tey'
+  s.email       = 'ben.tey@outlook.com'
+  s.homepage    = 'https://github.com/btey/openproject-gitlab-integration'
   s.summary     = 'OpenProject GitLab Integration'
   s.description = 'Integrates OpenProject and GitLab for a better workflow'
   s.license     = 'GPLv3'
 
-  s.files = Dir["{app,config,db,frontend,lib}/**/*"] + %w(README.md)
+  s.files = Dir['{app,config,db,frontend,lib}/**/*'] + %w[README.md]
 
-  s.add_dependency "openproject-webhooks"
+  s.add_dependency 'openproject-webhooks'
 end


### PR DESCRIPTION
Closes https://github.com/btey/openproject-gitlab-integration/issues/48

1. Fix 500 errors on OP backend when GitLab users create MR and Issue with empty description body. Stores "No description provided" instead of an empty body.
2. Fix 500 error when GitLab user has no avatar (avatar_url is null). Empty avatar_url is replaced by dummy avatar URL.
3. Fixed russian locale config.
4. Some style fix with rubocop.
5. Gem version updated from 2.1 to 2.1.1
6. `README.md` updated.
7. Successfuly tested by me.