### PR TITLE
Add support for global push events using system hook

### DIFF
--- a/lib/open_project/gitlab_integration/engine.rb
+++ b/lib/open_project/gitlab_integration/engine.rb
@@ -69,6 +69,8 @@ module OpenProject::GitlabIntegration
                                              &NotificationHandlers.method(:push_hook))
       ::OpenProject::Notifications.subscribe('gitlab.pipeline_hook',
                                              &NotificationHandlers.method(:pipeline_hook))
+      ::OpenProject::Notifications.subscribe('gitlab.system_hook',
+                                             &NotificationHandlers.method(:system_hook))
     end
 
     extend_api_response(:v3, :work_packages, :work_package,

--- a/lib/open_project/gitlab_integration/hook_handler.rb
+++ b/lib/open_project/gitlab_integration/hook_handler.rb
@@ -36,6 +36,7 @@ module OpenProject::GitlabIntegration
       note_hook 
       merge_request_hook
       pipeline_hook
+      system_hook
     ].freeze
 
     # A gitlab webhook happened.

--- a/lib/open_project/gitlab_integration/notification_handler/system_hook.rb
+++ b/lib/open_project/gitlab_integration/notification_handler/system_hook.rb
@@ -1,0 +1,67 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2023 Ben Tey
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject::GitlabIntegration
+  module NotificationHandler
+    ##
+    # Handles Gitlab commit notifications.
+    class PushHook
+      include OpenProject::GitlabIntegration::NotificationHandler::Helper
+      
+      def process(payload_params)
+        @payload = wrap_payload(payload_params)
+        return nil unless payload.object_kind == 'push'
+        payload.commits.each do |commit|
+          user = User.find_by_id(payload.open_project_user_id)
+          text = commit['title'] + " - " + commit['message']
+          work_packages = find_mentioned_work_packages(text, user)
+          notes = generate_notes(commit, payload)
+          comment_on_referenced_work_packages(work_packages, user, notes)
+        end
+      end
+
+      private
+
+      attr_reader :payload
+
+      def generate_notes(commit, payload)
+        commit_id = commit['id']
+        I18n.t("gitlab_integration.push_single_commit_comment",
+          :commit_number => commit_id[0, 8],
+          :commit_note => commit['message'],
+          :commit_url => commit['url'],
+          :commit_timestamp => commit['timestamp'],
+          :repository => payload.repository.name,
+          :repository_url => payload.repository.homepage,
+          :gitlab_user => payload.user_name,
+          :gitlab_user_url => payload.user_avatar)
+      end
+    end
+  end
+end

--- a/lib/open_project/gitlab_integration/notification_handler/system_hook.rb
+++ b/lib/open_project/gitlab_integration/notification_handler/system_hook.rb
@@ -31,7 +31,7 @@ module OpenProject::GitlabIntegration
   module NotificationHandler
     ##
     # Handles Gitlab commit notifications.
-    class PushHook
+    class SystemHook
       include OpenProject::GitlabIntegration::NotificationHandler::Helper
       
       def process(payload_params)

--- a/lib/open_project/gitlab_integration/notification_handlers.rb
+++ b/lib/open_project/gitlab_integration/notification_handlers.rb
@@ -69,6 +69,12 @@ module OpenProject::GitlabIntegration
         end
       end
 
+      def pipeline_hook(payload)
+        with_logging('system_hook') do
+          OpenProject::GitlabIntegration::NotificationHandler::SystemHook.new.process(payload)
+        end
+      end
+
       private
 
       def with_logging(event_hook)

--- a/lib/open_project/gitlab_integration/notification_handlers.rb
+++ b/lib/open_project/gitlab_integration/notification_handlers.rb
@@ -70,7 +70,7 @@ module OpenProject::GitlabIntegration
         end
       end
 
-      def pipeline_hook(payload)
+      def system_hook(payload)
         with_logging('system_hook') do
           OpenProject::GitlabIntegration::NotificationHandler::SystemHook.new.process(payload)
         end

--- a/lib/open_project/gitlab_integration/notification_handlers.rb
+++ b/lib/open_project/gitlab_integration/notification_handlers.rb
@@ -32,6 +32,7 @@ require_relative './notification_handler/issue_hook'
 require_relative './notification_handler/merge_request_hook'
 require_relative './notification_handler/note_hook'
 require_relative './notification_handler/push_hook'
+require_relative './notification_handler/system_hook'
 
 module OpenProject::GitlabIntegration
 


### PR DESCRIPTION
Gitlab allows you to add system level webhooks for push events. It would be nice to be able to collect all push notifications on an entire gitlab instance in open project.